### PR TITLE
[FE] ScrollToTop 기능 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,12 +1,14 @@
 import PageLayout from "./layouts/pages";
 
 import { BrowserRouter as Router } from "react-router-dom";
+import ScrollToTop from "./components/ScrollToTop";
 import Routes from "./routes";
 
 function App() {
   return (
     <Router>
       <PageLayout>
+        <ScrollToTop />
         <Routes />
       </PageLayout>
     </Router>

--- a/src/components/ScrollToTop/index.jsx
+++ b/src/components/ScrollToTop/index.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
+export default ScrollToTop;


### PR DESCRIPTION
# 개요

#11 에서의 문제가 페이지 이동시 스크롤의 위치는 고정이였던 문제가 있었다. <br />
이것을 useEffect와 useLocation을 사용하여 페이지 변경시 스크롤을 최상단으로 이동하게 수정하였다.
![feat1](https://user-images.githubusercontent.com/74192619/222953106-2cee1a02-1b0a-493f-9061-24b0a3f58b88.gif)

## Ref

[react router 페이지 상단으로 올리기](https://han-py.tistory.com/455)